### PR TITLE
npm 9 introduces strict peer dep checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "sinon": "^13.0.2"
   },
   "peerDependencies": {
-    "ember-cli": "^3.2.0 || ^4.0.0 || ^5.0.0"
+    "ember-cli": "^3.2.0 || >=4.0.0"
   },
   "engines": {
     "node": ">= 6"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "sinon": "^13.0.2"
   },
   "peerDependencies": {
-    "ember-cli": "^3.2.0 || ^4.0.0"
+    "ember-cli": "^3.2.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
Resolves: https://github.com/ember-cli/ember-cli/issues/10284
(or begins to)

also submitted here: https://github.com/quaertym/ember-cli-dependency-checker/pull/144

